### PR TITLE
viogpu3d: Fix build error on VS2022 and refine code segments

### DIFF
--- a/viogpu/viogpu3d/driver.cpp
+++ b/viogpu/viogpu3d/driver.cpp
@@ -36,8 +36,9 @@
 #include "viogpu_adapter.h"
 #include "viogpu_device.h"
 
-#pragma code_seg(push)
-#pragma code_seg("INIT")
+// BEGIN: Non-paged data
+#pragma data_seg(push)
+#pragma data_seg()
 
 int nDebugLevel;
 int virtioDebugLevel;
@@ -45,6 +46,16 @@ int bDebugPrint;
 int bBreakAlways;
 
 tDebugPrintFunc VirtioDebugPrintProc;
+
+#pragma data_seg(pop)
+// END: Non-paged data
+
+#include <ntddk.h>
+#include "viogpu_device.h"
+
+// BEGIN: Init code
+#pragma code_seg(push)
+#pragma code_seg("INIT")
 
 #ifdef DBG
 void InitializeDebugPrints(IN PDRIVER_OBJECT DriverObject, IN PUNICODE_STRING RegistryPath)
@@ -68,16 +79,13 @@ void InitializeDebugPrints(IN PDRIVER_OBJECT DriverObject, IN PUNICODE_STRING Re
 }
 #endif
 
-#include <ntddk.h>
-#include "viogpu_device.h"
-
-#pragma code_seg(push)
-#pragma code_seg("PAGE")
 extern "C" NTSTATUS DriverEntry(_In_ DRIVER_OBJECT *pDriverObject, _In_ UNICODE_STRING *pRegistryPath)
 {
     PAGED_CODE();
     VIOGPU_TRACE_INIT(pDriverObject, pRegistryPath);
+#ifdef DBG
     DbgPrint(TRACE_LEVEL_FATAL, ("---> VIOGPU FULL build on on %s %s\n", __DATE__, __TIME__));
+#endif
     DRIVER_INITIALIZATION_DATA InitialData = {0};
 
     InitialData.Version = DXGKDDI_INTERFACE_VERSION_WDDM1_3;

--- a/viogpu/viogpu3d/trace.h
+++ b/viogpu/viogpu3d/trace.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "kdebugprint.h"
 
-#define DBG 1
+// #define DBG 1
 
 #ifndef TRACE_LEVEL_INFORMATION
 #define TRACE_LEVEL_NONE        0   // Tracing is not on

--- a/viogpu/viogpu3d/viogpu_adapter.cpp
+++ b/viogpu/viogpu3d/viogpu_adapter.cpp
@@ -277,6 +277,7 @@ NTSTATUS VioGpuAdapter::StopDevice(VOID)
     PAGED_CODE();
 
     virtio_device_reset(&m_VioDev);
+    vidpn.Stop();
 
     m_Flags.DriverStarted = FALSE;
     return STATUS_SUCCESS;

--- a/viogpu/viogpu3d/viogpu_vidpn.cpp
+++ b/viogpu/viogpu3d/viogpu_vidpn.cpp
@@ -122,7 +122,9 @@ NTSTATUS VioGpuVidPN::Start(ULONG *pNumberOfViews, ULONG *pNumberOfChildren)
     InterlockedExchange(&m_sourceAddressQueueHead, 0);
     InterlockedExchange(&m_sourceAddressQueueTail, 0);
     InterlockedExchange(&m_sourceQueueFullCount, 0);
-    KeInitializeTimerEx(&m_vsyncNotifyTimer, SynchronizationTimer);
+
+    m_pVsyncNotifyTimer = new (NonPagedPoolNx) KTIMER;
+    KeInitializeTimerEx(m_pVsyncNotifyTimer, SynchronizationTimer);
     KeInitializeDpc(&m_vsyncNotifyDpc, VioGpuVidPN::VsyncNotifyTimerDpc, this);
     m_timerRes = ExSetTimerResolution(10000, TRUE);
     {
@@ -131,8 +133,22 @@ NTSTATUS VioGpuVidPN::Start(ULONG *pNumberOfViews, ULONG *pNumberOfChildren)
         KeQuerySystemTime(&now);
         next_vsync_time.QuadPart = now.QuadPart + kVsyncPeriod100ns;
         due.QuadPart = -kVsyncPeriod100ns;
-        KeSetTimerEx(&m_vsyncNotifyTimer, due, 0, &m_vsyncNotifyDpc);
+        KeSetTimerEx(m_pVsyncNotifyTimer, due, 0, &m_vsyncNotifyDpc);
     }
+    return Status;
+}
+
+NTSTATUS VioGpuVidPN::Stop(void)
+{
+    PAGED_CODE();
+    NTSTATUS Status = STATUS_SUCCESS;
+
+    if (m_pVsyncNotifyTimer)
+    {
+        KeCancelTimer(m_pVsyncNotifyTimer);
+        m_pVsyncNotifyTimer = NULL;
+    }
+
     return Status;
 }
 
@@ -163,7 +179,11 @@ void VioGpuVidPN::ReleasePostDisplayOwnership(D3DDDI_VIDEO_PRESENT_TARGET_ID Tar
 
     InterlockedExchange(&m_shouldFlipStop, 1);
 
-    KeCancelTimer(&m_vsyncNotifyTimer);
+    if (m_pVsyncNotifyTimer)
+    {
+        KeCancelTimer(m_pVsyncNotifyTimer);
+        m_pVsyncNotifyTimer = NULL;
+    }
     KeFlushQueuedDpcs();
 
     if (m_timerRes)
@@ -2085,7 +2105,14 @@ void VioGpuVidPN::VsyncNotifyTimerDpc(KDPC *dpc, PVOID deferredContext, PVOID sy
     // submit a NOP to trigger the ISR generate CRTC_VSYNC
     vidpn->m_pAdapter->ctrlQueue.SubmitNop(NULL, NULL, FALSE);
 
-    KeSetTimerEx(&vidpn->m_vsyncNotifyTimer, next, 0, &vidpn->m_vsyncNotifyDpc);
+    if (vidpn->m_pVsyncNotifyTimer)
+    {
+        KeSetTimerEx(vidpn->m_pVsyncNotifyTimer, next, 0, &vidpn->m_vsyncNotifyDpc);
+    }
+    else
+    {
+        DbgPrint(TRACE_LEVEL_ERROR, ("%s: vsync notify timer is null\n", __FUNCTION__));
+    }
 }
 
 

--- a/viogpu/viogpu3d/viogpu_vidpn.h
+++ b/viogpu/viogpu3d/viogpu_vidpn.h
@@ -46,6 +46,7 @@ class VioGpuVidPN
     ~VioGpuVidPN();
 
     NTSTATUS Start(ULONG *pNumberOfViews, ULONG *pNumberOfChildren);
+    NTSTATUS Stop(void);
     NTSTATUS AcquirePostDisplayOwnership();
     void ReleasePostDisplayOwnership(D3DDDI_VIDEO_PRESENT_TARGET_ID TargetId, DXGK_DISPLAY_INFORMATION *pDisplayInfo);
     void Powerdown();
@@ -155,7 +156,7 @@ class VioGpuVidPN
 
 
     volatile LONG m_shouldFlipStop = 0;
-    KTIMER m_vsyncNotifyTimer;
+    PKTIMER m_pVsyncNotifyTimer;
     KDPC m_vsyncNotifyDpc;
     ULONG m_timerRes = 0;
     LARGE_INTEGER next_vsync_time = {0};


### PR DESCRIPTION
    - Comment the *DBG* define in code, letting VS decide decide it via project config.
    - Move print flag to non-paged data segment, as it may be used in both paged & non-paged code.
    - Move init code to init code segment.
    - Disable __DATE__ / __TIME__ output in Release, latest VS2022 enable SDL check by default, and these macro will lead build error.